### PR TITLE
print suppressed exceptions & their parents information into exception message

### DIFF
--- a/src/SuppressedExceptions.php
+++ b/src/SuppressedExceptions.php
@@ -14,6 +14,7 @@ trait SuppressedExceptions /* implements WithSuppressedExceptions */
 	public function addSuppressed(\Throwable ...$exceptions): void
 	{
 		foreach($exceptions as $exception) {
+			$this->addTextVersionOfExceptionToMessage($exception);
 			$this->suppressedExceptions[] = $exception;
 		}
 	}
@@ -21,6 +22,45 @@ trait SuppressedExceptions /* implements WithSuppressedExceptions */
 	public function getSuppressed(): array
 	{
 		return $this->suppressedExceptions;
+	}
+
+	private function addTextVersionOfExceptionToMessage(\Throwable $throwable): void
+	{
+		if ($this->suppressedExceptions === []) {
+			$this->message .= "\nSuppressed exceptions:\n";
+		}
+
+		$moveRight = function(string $textToMoveRight, int $offset): string {
+			$replaceWith = "\n" . \str_repeat(' ', $offset);
+			return str_replace(
+				["\r\n","\n","\r"],
+				$replaceWith,
+				$textToMoveRight
+			);
+		};
+
+		$renderSingle = function(\Throwable $throwable): string {
+			$message = $throwable->getMessage();
+			$type = \get_class($throwable);
+			$message =
+				$message === ''
+					? $type
+					: "{$message} ({$type})";
+
+			$fileRelativePath = str_replace(\getcwd() . DIRECTORY_SEPARATOR, '', $throwable->getFile());
+			return "{$fileRelativePath}:{$throwable->getLine()} - {$message}";
+		};
+
+		$renderTree = function(\Throwable $throwable) use ($moveRight, $renderSingle): string {
+			$string = $renderSingle($throwable);
+			$previous = $throwable;
+			while (($previous = $previous->getPrevious()) !== NULL) {
+				$string .= "\n  previous: {$moveRight($renderSingle($previous), 12)}";
+			}
+			return $string;
+		};
+
+		$this->message .= "- {$moveRight($renderTree($throwable), 2)}\n";
 	}
 
 }

--- a/tests/nested.phpt
+++ b/tests/nested.phpt
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Grifart\SuppressedExceptions\__tests;
+
+use Grifart\SuppressedExceptions\SuppressedExceptions;
+use Grifart\SuppressedExceptions\WithSuppressedExceptions;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+class TestingSuppressedExceptionsException extends \RuntimeException implements WithSuppressedExceptions
+{
+	use SuppressedExceptions;
+
+}
+
+$previous = new TestingSuppressedExceptionsException('previous', -1, new RuntimeException());
+$exception1 = new TestingSuppressedExceptionsException('message', 42, $previous);
+$exception1->addSuppressed(new RuntimeException('message', 0, $previous));
+
+$exception2 = new TestingSuppressedExceptionsException('message2', 42);
+$exception2->addSuppressed($previous);
+$exception2->addSuppressed($exception1);
+
+Assert::exception(
+	function() use ($exception2) {
+		throw $exception2;
+	},
+	TestingSuppressedExceptionsException::class,
+	\file_get_contents(__DIR__ . '/nested_exception-message.txt')
+);

--- a/tests/nested_exception-message.txt
+++ b/tests/nested_exception-message.txt
@@ -1,0 +1,12 @@
+message2
+Suppressed exceptions:
+- nested.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
+    previous: nested.phpt:18 - Symfony\Component\Console\Exception\RuntimeException
+- nested.phpt:19 - message
+  Suppressed exceptions:
+  - nested.phpt:20 - message (Symfony\Component\Console\Exception\RuntimeException)
+      previous: nested.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
+      previous: nested.phpt:18 - Symfony\Component\Console\Exception\RuntimeException
+   (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
+    previous: nested.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
+    previous: nested.phpt:18 - Symfony\Component\Console\Exception\RuntimeException

--- a/tests/simple.phpt
+++ b/tests/simple.phpt
@@ -19,15 +19,19 @@ $previous = new TestingSuppressedExceptionsException('previous', -1, new Runtime
 $exception = new TestingSuppressedExceptionsException('message', 42, $previous);
 
 $exception->addSuppressed($suppressed1 = new \RuntimeException());
-$exception->addSuppressed($suppressed2 = new \LogicException());
+$exception->addSuppressed($suppressed2 = new \LogicException('This is message'));
 $exception->addSuppressed($suppressed3 = new \Error());
-$exception->addSuppressed($suppressed4 = new \Exception());
+$exception->addSuppressed($suppressed4 = new \Exception('With previous', 0, $previous));
 $exception->addSuppressed($suppressed5 = new TestingSuppressedExceptionsException());
 
 // test that can be thrown
-Assert::exception(function() use ($exception) {
-	throw $exception;
-}, TestingSuppressedExceptionsException::class);
+Assert::exception(
+	function() use ($exception) {
+		throw $exception;
+	},
+	TestingSuppressedExceptionsException::class,
+	\file_get_contents(__DIR__ . '/simple_exception-message.txt')
+);
 
 // previous
 Assert::same($previous, $exception->getPrevious());

--- a/tests/simple.phpt
+++ b/tests/simple.phpt
@@ -4,7 +4,6 @@ namespace Grifart\SuppressedExceptions\__tests;
 
 use Grifart\SuppressedExceptions\SuppressedExceptions;
 use Grifart\SuppressedExceptions\WithSuppressedExceptions;
-use Symfony\Component\Console\Exception\RuntimeException;
 use Tester\Assert;
 
 require __DIR__ . '/bootstrap.php';
@@ -15,7 +14,7 @@ class TestingSuppressedExceptionsException extends \RuntimeException implements 
 
 }
 
-$previous = new TestingSuppressedExceptionsException('previous', -1, new RuntimeException());
+$previous = new TestingSuppressedExceptionsException('previous', -1, new \RuntimeException());
 $exception = new TestingSuppressedExceptionsException('message', 42, $previous);
 
 $exception->addSuppressed($suppressed1 = new \RuntimeException());

--- a/tests/simple_exception-message.txt
+++ b/tests/simple_exception-message.txt
@@ -1,0 +1,9 @@
+message
+Suppressed exceptions:
+- simple.phpt:21 - RuntimeException
+- simple.phpt:22 - This is message (LogicException)
+- simple.phpt:23 - Error
+- simple.phpt:24 - With previous (Exception)
+    previous: simple.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
+    previous: simple.phpt:18 - Symfony\Component\Console\Exception\RuntimeException
+- simple.phpt:25 - Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException

--- a/tests/simple_exception-message.txt
+++ b/tests/simple_exception-message.txt
@@ -1,9 +1,9 @@
 message
 Suppressed exceptions:
-- simple.phpt:21 - RuntimeException
-- simple.phpt:22 - This is message (LogicException)
-- simple.phpt:23 - Error
-- simple.phpt:24 - With previous (Exception)
-    previous: simple.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
-    previous: simple.phpt:18 - Symfony\Component\Console\Exception\RuntimeException
-- simple.phpt:25 - Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException
+- simple.phpt:20 - RuntimeException
+- simple.phpt:21 - This is message (LogicException)
+- simple.phpt:22 - Error
+- simple.phpt:23 - With previous (Exception)
+    previous: simple.phpt:17 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
+    previous: simple.phpt:17 - RuntimeException
+- simple.phpt:24 - Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException


### PR DESCRIPTION
(as this is supported by all debugging tools)

e.g. - when error happened in test:
```console
Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException: message2
Suppressed exceptions:
- nested.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
    previous: nested.phpt:18 - Symfony\Component\Console\Exception\RuntimeException
- nested.phpt:19 - message
  Suppressed exceptions:
  - nested.phpt:20 - message (Symfony\Component\Console\Exception\RuntimeException)
      previous: nested.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
      previous: nested.phpt:18 - Symfony\Component\Console\Exception\RuntimeException
   (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
    previous: nested.phpt:18 - previous (Grifart\SuppressedExceptions\__tests\TestingSuppressedExceptionsException)
    previous: nested.phpt:18 - Symfony\Component\Console\Exception\RuntimeException


in grifart-suppressed-exceptions/tests/nested.phpt(22) 
```